### PR TITLE
Resolved deserialization error

### DIFF
--- a/internal/adapters/secondary/rest/models/versioning.go
+++ b/internal/adapters/secondary/rest/models/versioning.go
@@ -10,7 +10,7 @@ type OctyGetVersionInfoResp struct {
 
 type CurrentVersion struct {
 	ID          string  `json:"id"`
-	ReleaseID   int64   `json:"release_id"`
+	ReleaseID   string  `json:"release_id"`
 	VersionTag  string  `json:"version_tag"`
 	VersionName string  `json:"version_name"`
 	VersionInt  int64   `json:"version_int"`

--- a/pkg/globals/globals.go
+++ b/pkg/globals/globals.go
@@ -7,7 +7,7 @@ import (
 // versioning
 const (
 	ApiVersion = "v1-beta"
-	CliVersion = "v1.0.1-alpha"
+	CliVersion = "v1.0.2-alpha"
 )
 
 // Octy Docs links


### PR DESCRIPTION
- CurrentVersion > ReleaseID is now returned as a string (not int) in API response.
- version bump